### PR TITLE
Ajout du support OpenLLM dans audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Audit Upgrade
 
-Script `audit_upgrade.py` analyse les mises à jour disponibles pour les paquets Debian et génère un rapport sur les risques de breaking changes. Il interroge l'API OpenAI pour valider la compatibilité des fichiers de configuration.
+Script `audit_upgrade.py` analyse les mises à jour disponibles pour les paquets Debian et génère un rapport sur les risques de breaking changes. Il peut interroger l'API OpenAI ou un serveur OpenLLM compatible pour valider la compatibilité des fichiers de configuration.
 
 ## Utilisation
 
@@ -16,11 +16,19 @@ Puis lancez le script :
 python3 audit_upgrade.py --openai-key MON_API_KEY
 ```
 
+Pour utiliser un serveur OpenLLM local :
+
+```bash
+python3 audit_upgrade.py --llm openllm --openllm-port 3000
+```
+
 Options principales :
 - `--installed-file` : fichier contenant la sortie `apt list --installed`.
 - `--upgradable-file` : fichier contenant la sortie `apt list --upgradable`.
 - `--format {md,html}` : format du rapport.
 - `--no-email` : ne pas envoyer le rapport par mail, l'enregistrer localement.
+- `--llm {openai,openllm}` : choix du modèle de langage à utiliser.
+- `--openllm-port` : port du serveur OpenLLM (3000 par défaut).
 ```
 
 Le script n'effectue aucune mise à jour; il se contente de produire un rapport.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests>=2.32.0
+openllm>=0.6.30


### PR DESCRIPTION
## Summary
- add openllm as dependency
- add openllm request option and CLI support
- print progress info while running

## Testing
- `python -m py_compile audit_upgrade.py`
- `pip check`
- `python audit_upgrade.py --installed-file installed.txt --upgradable-file upgradable.txt --llm openllm --openllm-port 3000 --no-email --output test.md`

------
https://chatgpt.com/codex/tasks/task_e_6852abcbcfdc832a9037d93611c1e6b8