### PR TITLE
Ajout du support OpenLLM dans audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Audit Upgrade
 
-Script `audit_upgrade.py` analyse les mises à jour disponibles pour les paquets Debian et génère un rapport sur les risques de breaking changes. Il interroge l'API OpenAI pour valider la compatibilité des fichiers de configuration.
+Script `audit_upgrade.py` analyse les mises à jour disponibles pour les paquets Debian et génère un rapport sur les risques de breaking changes. Il peut interroger l'API OpenAI ou un serveur OpenLLM compatible pour valider la compatibilité des fichiers de configuration.
 
 ## Utilisation
 
@@ -16,11 +16,20 @@ Puis lancez le script :
 python3 audit_upgrade.py --openai-key MON_API_KEY
 ```
 
+Pour utiliser un serveur OpenLLM local :
+
+```bash
+python3 audit_upgrade.py --llm openllm --openllm-url http://localhost:3000/v1/chat/completions
+```
+
 Options principales :
 - `--installed-file` : fichier contenant la sortie `apt list --installed`.
 - `--upgradable-file` : fichier contenant la sortie `apt list --upgradable`.
 - `--format {md,html}` : format du rapport.
 - `--no-email` : ne pas envoyer le rapport par mail, l'enregistrer localement.
+- `--llm {openai,openllm}` : choix du modèle de langage à utiliser.
+- `--openllm-url` : URL complète du serveur OpenLLM.
+- `--openllm-key` : clé API pour OpenLLM (optionnel).
 ```
 
 Le script n'effectue aucune mise à jour; il se contente de produire un rapport.

--- a/audit_upgrade.py
+++ b/audit_upgrade.py
@@ -17,6 +17,7 @@ from typing import Dict, List, Optional
 import requests
 
 API_URL = "https://api.openai.com/v1/chat/completions"
+DEFAULT_OPENLLM_URL = "http://localhost:3000/v1/chat/completions"
 MODEL = "gpt-3.5-turbo"
 
 def run_cmd(command: str) -> str:
@@ -106,6 +107,21 @@ def openai_request(prompt: str, key: str) -> str:
         return f"OpenAI request failed: {exc}"
 
 
+def openllm_request(prompt: str, url: str, key: str) -> str:
+    headers = {"Authorization": f"Bearer {key or 'local'}"}
+    data = {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": 0,
+    }
+    try:
+        resp = requests.post(url, headers=headers, json=data, timeout=30)
+        resp.raise_for_status()
+        return resp.json()["choices"][0]["message"]["content"].strip()
+    except Exception as exc:
+        return f"OpenLLM request failed: {exc}"
+
+
 def analyze_package(
     name: str,
     current: str,
@@ -113,6 +129,9 @@ def analyze_package(
     config_path: Optional[str],
     changelog: str,
     key: str,
+    llm: str,
+    openllm_url: str,
+    openllm_key: str,
 ) -> Dict[str, object]:
     prompt = (
         f"Nous envisageons de mettre à jour le paquet {name} de la version {current} "
@@ -130,7 +149,12 @@ def analyze_package(
             prompt += f"\n\nConfiguration actuelle:\n```\n{config_content}\n```"
         except Exception:
             pass
-    answer = openai_request(prompt, key)
+    if llm == "openllm":
+        print("  -> interrogation du serveur OpenLLM")
+        answer = openllm_request(prompt, openllm_url, openllm_key)
+    else:
+        print("  -> interrogation de l'API OpenAI")
+        answer = openai_request(prompt, key)
     safe = "safe" in answer.lower() and "not safe" not in answer.lower()
     breaking = "breaking" in answer.lower()
     return {
@@ -197,25 +221,45 @@ def main() -> None:
     parser.add_argument("--output", default="upgrade_report.md", help="Fichier de sortie si --no-email")
     parser.add_argument("--format", choices=["md", "html"], default="md", help="Format du rapport")
     parser.add_argument("--openai-key", help="Clé API OpenAI (ou via OPENAI_API_KEY)")
+    parser.add_argument("--llm", choices=["openai", "openllm"], default="openai", help="Fournisseur du LLM")
+    parser.add_argument("--openllm-url", default=DEFAULT_OPENLLM_URL, help="URL du serveur OpenLLM")
+    parser.add_argument("--openllm-key", help="Clé API OpenLLM (ou via OPENLLM_API_KEY)")
     parser.add_argument("--recipient", default="root", help="Destinataire du mail")
     args = parser.parse_args()
 
     key = args.openai_key or os.getenv("OPENAI_API_KEY")
-    if not key:
+    openllm_key = args.openllm_key or os.getenv("OPENLLM_API_KEY", "")
+    if args.llm == "openai" and not key:
         print("Clé API OpenAI requise", file=sys.stderr)
         sys.exit(1)
 
+    print("Récupération des paquets installés...")
     installed = get_installed_packages(args.installed_file)
+    print(f"{len(installed)} paquets installés détectés")
+    print("Récupération des paquets upgradables...")
     upgradable = get_upgradable_packages(args.upgradable_file)
+    print(f"{len(upgradable)} mises à jour disponibles")
 
     items: List[Dict[str, object]] = []
     for pkg, candidate_version in upgradable.items():
+        print(f"Analyse du paquet {pkg}...")
         current_version = installed.get(pkg, "")
         config = find_config_path(pkg)
         changelog = load_changelog(pkg)
-        item = analyze_package(pkg, current_version, candidate_version, config, changelog, key)
+        item = analyze_package(
+            pkg,
+            current_version,
+            candidate_version,
+            config,
+            changelog,
+            key,
+            args.llm,
+            args.openllm_url,
+            openllm_key,
+        )
         items.append(item)
 
+    print("Génération du rapport...")
     report = generate_report(items, args.format)
 
     if args.no_email:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests>=2.32.0
+openllm>=0.6.30


### PR DESCRIPTION
## Summary
- add openllm as dependency
- add openllm request option and CLI support
- print progress info while running
- support full OpenLLM URL and API key

## Testing
- `python -m py_compile audit_upgrade.py`
- `pip check`
- `python audit_upgrade.py --installed-file installed.txt --upgradable-file upgradable.txt --llm openllm --openllm-url http://localhost:3000/v1/chat/completions --openllm-key local --no-email --output test.md`
- `python audit_upgrade.py --installed-file installed.txt --upgradable-file upgradable.txt --openai-key dummy --no-email --output test2.md`


------
https://chatgpt.com/codex/tasks/task_e_6852abcbcfdc832a9037d93611c1e6b8